### PR TITLE
fix pure evaluation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,10 @@
 
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
-      let pkgs = import nixpkgs { system = system; };
+      let pkgs = import nixpkgs {
+        system = system;
+        config.allowUnfree = true;
+      };
       in rec {
         packages = flake-utils.lib.flattenTree {
           dirbuster = pkgs.callPackage ./pkgs/tools/security/dirbuster { };


### PR DESCRIPTION
Fixes #1.

This allows pure evaluations to go through despite the unfree license. Compared to an overlay, the slight downside is that downstream flakes cannot filter unfree packages as effectively, (they have to hack an overlay in) but given the specific circumstances I don't think this is a big deal.

Compare the following commands, they no longer trip the error:
```sh
nix build .#msodbcsql # flake version
nix-build --pure -A packages.x86_64-linux.msodbcsql # legacy equivalent
```